### PR TITLE
fix(.gitattributes): reduce dist size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,8 +11,8 @@
 /phpdoc.xml               export-ignore
 /phpolar.svg              export-ignore
 /phpunit.xml              export-ignore
-/phpunit-ci.xml           export-ignore
-/phpunit-dev.xml          export-ignore
+/phpunit.ci.xml           export-ignore
+/phpunit.dev.xml          export-ignore
 /.pre-commit-config.yaml  export-ignore
 /README.md                export-ignore
 /SECURITY.md              export-ignore


### PR DESCRIPTION
The unit test configuration files were missed in the last fix :roll_eyes:.

Issue https://github.com/phpolar/storage-driver/issues/5, Closes https://github.com/phpolar/storage-driver/issues/5